### PR TITLE
Add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+*.swp
+.Python
+env/
+*.egg-info
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.10-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app ./app
+
+EXPOSE 8000
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -15,8 +15,22 @@ A small FastAPI server exposing Docker Swarm and optional Portainer management e
 
 3. Start the server:
    ```bash
-   uvicorn app.main:app --reload
-   ```
+uvicorn app.main:app --reload
+```
+
+## Docker
+
+Build the image:
+
+```bash
+docker build -t aidock .
+```
+
+Run the container (mount the Docker socket if controlling the host):
+
+```bash
+docker run -p 8000:8000 -v /var/run/docker.sock:/var/run/docker.sock aidock
+```
 
 ## Example `curl` commands
 


### PR DESCRIPTION
## Summary
- containerize FastAPI app with a new Dockerfile
- ignore build artifacts via `.dockerignore`
- document container usage in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68817520dfe48325a838ff2404e1bb6e